### PR TITLE
Added C++ computeTrace() function that works for dgeMatrix/dgCMatrix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,13 @@
 Package: mvwgaim
 Type: Package
 Title: Multi-(environment/variate/treatment) whole genome QTL analysis using ASReml-R V4
-Version: 0.99-0
-Date: 2021-11-10
+Version: 0.99-1
+Date: 2024-04-06
 Author: Julian Taylor <julian.taylor@adelaide.edu.au> 
 Maintainer: Julian Taylor <julian.taylor@adelaide.edu.au>
 Depends: R (>= 3.0.0), qtl, wgaim
-Imports: ggplot2, MASS
+LinkingTo: Rcpp
+Imports: ggplot2, MASS, Rcpp
 SystemRequirements: asreml-R 4.x
 Description: This package conducts whol genome multi-(envronment/treatment/variate) QTL/Association analysis using the functionality of the linear mixed modelling R package ASReml-R V4.  
 License: GPL (>= 2)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,7 +7,8 @@ grDevices,
 qtl,
 wgaim,
 ggplot2,
-MASS)
+MASS,
+Rcpp)
 
 ##[exports]
 export(
@@ -30,3 +31,4 @@ S3method(mvwgaim, asreml)
 S3method(mvwgaim, default)
 S3method(waldTest, asreml)
 
+useDynLib(mvwgaim)

--- a/R/mvwgaimNov21.R
+++ b/R/mvwgaimNov21.R
@@ -434,7 +434,8 @@ qtlMSelect <- function(asm, phenoData, genObj, gen.type, selection, n.fa, Trait,
     vqtilde <- apply(trans, 1, function(el, Ginv, vatilde){
         tmp1 <- kronecker(diag(n.trait), el)
         tmp2 <- t(tmp1) %*% vatilde %*% tmp1
-        sum(diag(Ginv %*% tmp2))
+        #sum(diag(Ginv %*% tmp2))
+        computeTrace(Ginv %*% tmp2)  # Using C++ function
     }, Ginv, vatilde)
     gnams <- names(state)[as.logical(state)]
     names(qtilde) <- names(vqtilde) <- gnams

--- a/mvwgaim.Rproj
+++ b/mvwgaim.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/src/computeTrace.cpp
+++ b/src/computeTrace.cpp
@@ -1,0 +1,59 @@
+/**
+ * C++ code for the trace computation (to speed up processing
+ * of massive matrices in qtlMSelect()).
+ *
+ * Code author: Russell Edson, Biometry Hub
+ * Date last modified: 06/04/2024
+ */
+
+#include <string>
+#include <vector>
+
+#include <Rcpp.h>
+
+//' Computes the trace of a given S4 Matrix class
+//'
+//' @param mat The matrix to compute the trace for
+//' @return The trace (i.e. sum of diagonal entries)
+//' @noRd
+// [[Rcpp::export]]
+double computeTrace(const Rcpp::S4 &mat) {
+  std::string className = mat.attr("class");
+  double trace = 0.0;
+
+  if (className == "dgeMatrix") {
+    // S4 structure of a dgeMatrix:
+    //   Slot "Dim": IntegerVector of length 2 (for m, n dimensions)
+    //   Slot "x": NumericVector of length m*n (values in column-major order)
+    Rcpp::IntegerVector dim = mat.slot("Dim");
+    Rcpp::NumericVector x = mat.slot("x");
+
+    for (int k = 0; k < dim[1]; k++) {
+      trace += x[k*dim[0] + k];
+    }
+  } else if (className == "dgCMatrix") {
+    // S4 structure of a dgCMatrix:
+    //   Slot "Dim": IntegerVector of length 2 (for m, n dimensions)
+    //   Slot "x": NumericVector of length nz (non-zero entries)
+    //   Slot "i": IntegerVector of length nz (row indices, 0-based)
+    //   Slot "p": IntegerVector of length n+1 (column non-zero counts)
+    //Rcpp::IntegerVector dim = mat.slot("Dim");
+    Rcpp::NumericVector x = mat.slot("x");
+    Rcpp::IntegerVector i = mat.slot("i");
+    Rcpp::IntegerVector p = mat.slot("p");
+
+    int valPtr = 0;
+    for (int k = 0; k < p.size() - 1; k++) {
+      int nonzero = p[k + 1] - p[k];
+      for (int j = 0; j < nonzero; j++) {
+        if (i[valPtr + j] == k) {
+          trace += x[valPtr + j];
+        }
+      }
+      valPtr += nonzero;
+    }
+  } else {  //TODO: Other Matrix:: classes?
+    Rcpp::stop("computeTrace() not defined for objects of class " + className);
+  }
+  return trace;
+}


### PR DESCRIPTION
Adds the `computeTrace()` function (in the source file `src/computeTrace.cpp`) that sums the diagonal entries of a `Matrix` class (currently supports `dgeMatrix` and `dgCMatrix`, others can be added later if needed).

This fixes the error that Beata noticed about "long vectors not supported yet" in `qtlMSelect()`:
![image](https://github.com/DrJ001/mvwgaim/assets/8025610/de20a204-35e3-4d82-897d-d6bdf63d2e97)
What seems to be happening there is that `diag` isn't defined properly for the `Matrix::` matrices, so it's trying to read it as if it's a list or something instead. The easy fix would be to convert first using `as.matrix`, but if we expect these matrices to be very large then the C++ function instead makes more sense.
![image](https://github.com/DrJ001/mvwgaim/assets/8025610/38eabf30-5203-4828-931e-bfbd8744be8b)


