### PR TITLE
C++ implementation for vqtilde computation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,13 @@
 Package: mvwgaim
 Type: Package
 Title: Multi-(environment/variate/treatment) whole genome QTL analysis using ASReml-R V4
-Version: 0.99-0
-Date: 2021-11-10
+Version: 0.99-1
+Date: 2024-04-20
 Author: Julian Taylor <julian.taylor@adelaide.edu.au> 
 Maintainer: Julian Taylor <julian.taylor@adelaide.edu.au>
 Depends: R (>= 3.0.0), qtl, wgaim
-Imports: ggplot2, MASS
+LinkingTo: Rcpp, RcppArmadillo
+Imports: ggplot2, MASS, Rcpp (>= 1.0.12)
 SystemRequirements: asreml-R 4.x
 Description: This package conducts whol genome multi-(envronment/treatment/variate) QTL/Association analysis using the functionality of the linear mixed modelling R package ASReml-R V4.  
 License: GPL (>= 2)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -7,7 +7,9 @@ grDevices,
 qtl,
 wgaim,
 ggplot2,
-MASS)
+MASS,
+Rcpp,
+RcppArmadillo)
 
 ##[exports]
 export(
@@ -30,3 +32,4 @@ S3method(mvwgaim, asreml)
 S3method(mvwgaim, default)
 S3method(waldTest, asreml)
 
+useDynLib(mvwgaim, .registration=TRUE)

--- a/R/mvwgaimApr24.R
+++ b/R/mvwgaimApr24.R
@@ -430,11 +430,14 @@ qtlMSelect <- function(asm, phenoData, genObj, gen.type, selection, n.fa, Trait,
         vatilde <- kronecker(Ga, diag(nrow(atilde))) - pev
     }
     qtilde <- apply(qtilde, 1, function(el, Ginv) sum(c(t(el * Ginv)*el)), Ginv)
-    vqtilde <- apply(trans, 1, function(el, Ginv, vatilde){
-        tmp1 <- kronecker(diag(n.trait), el)
-        tmp2 <- t(tmp1) %*% vatilde %*% tmp1
-        sum(diag(Ginv %*% tmp2))
-    }, Ginv, vatilde)
+
+    #vqtilde <- apply(trans, 1, function(el, Ginv, vatilde){
+    #  tmp1 <- kronecker(diag(n.trait), el)
+    #  tmp2 <- t(tmp1) %*% vatilde %*% tmp1
+    #  sum(diag(as.matrix(Ginv %*% tmp2)))
+    #}, Ginv, vatilde)
+    vqtilde <- compute_vqtilde(trans, Ginv, as.matrix(vatilde), n.trait)
+    
     gnams <- names(state)[as.logical(state)]
     names(qtilde) <- names(vqtilde) <- gnams
     oint <- ifelse(!is.na(qtilde/vqtilde), qtilde/vqtilde, 0)

--- a/mvwgaim.Rproj
+++ b/mvwgaim.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,19 @@
+
+## With R 3.1.0 or later, you can uncomment the following line to tell R to
+## enable compilation with C++11 (where available)
+##
+## Also, OpenMP support in Armadillo prefers C++11 support. However, for wider
+## availability of the package we do not yet enforce this here.  It is however
+## recommended for client packages to set it.
+##
+## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
+## support within Armadillo prefers / requires it
+##
+## R 4.0.0 made C++11 the default, R 4.1.0 switched to C++14, R 4.3.0 to C++17
+## _In general_ we should no longer need to set a standard as any recent R
+## installation will do the right thing. Should you need it, uncomment it and
+## set the appropriate value, possibly CXX17.
+#CXX_STD = CXX11
+
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,19 @@
+
+## With R 3.1.0 or later, you can uncomment the following line to tell R to
+## enable compilation with C++11 (where available)
+##
+## Also, OpenMP support in Armadillo prefers C++11 support. However, for wider
+## availability of the package we do not yet enforce this here.  It is however
+## recommended for client packages to set it.
+##
+## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
+## support within Armadillo prefers / requires it
+##
+## R 4.0.0 made C++11 the default, R 4.1.0 switched to C++14, R 4.3.0 to C++17
+## _In general_ we should no longer need to set a standard as any recent R
+## installation will do the right thing. Should you need it, uncomment it and
+## set the appropriate value, possibly CXX17.
+#CXX_STD = CXX11
+
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/compute_vqtilde.cpp
+++ b/src/compute_vqtilde.cpp
@@ -1,0 +1,93 @@
+/**
+ * C+ code (using the Eigen libraries via RcppArmadillo) to compute the
+ * vqtilde component for the multivariate outlier statistics and speed
+ * up processing in the qtlSelect() function.
+ *
+ * Code author: Russell Edson, Biometry Hub
+ * Date last modified: 20/04/2024
+ */
+#include <RcppArmadillo.h>
+
+// [[Rcpp::depends(RcppArmadillo)]]
+
+//' Computes the matrix product vqtilde
+//'
+//' Note: This function assumes that the matrices passed in are all
+//' base R matrices (instead of Matrix::dgeMatrix types, for example).
+//'
+//' @param trans The matrix product M^T(MM^T)^{-1}, typically many rows
+//' @param Ginv The inverse matrix G_a^-
+//' @param vatilde The variance matrix var(tilde(a))
+//' @param ntrait The number of traits
+//' @return The matrix vqtilde
+//' @noRd
+// [[Rcpp::export]]
+Rcpp::NumericVector compute_vqtilde(Rcpp::NumericMatrix trans,
+    Rcpp::NumericMatrix Ginv, Rcpp::NumericMatrix vatilde, int ntrait) {
+  // Map input matrices to Armadillo matrix objects (without copying).
+  arma::uword n = trans.nrow(), p = trans.ncol();
+  arma::mat trans_mat = arma::mat(trans.begin(), n, p, false);
+  arma::mat Ginv_mat = arma::mat(Ginv.begin(), Ginv.nrow(), Ginv.ncol(), false);
+  arma::mat vatilde_mat = arma::mat(vatilde.begin(), vatilde.nrow(),
+      vatilde.ncol(), false);
+
+  // We augment the return value vqtilde with the expected row names.
+  Rcpp::NumericVector vqtilde(n);
+  Rcpp::List dimnames = trans.attr("dimnames");
+  Rcpp::CharacterVector rownames = dimnames[0];
+  vqtilde.attr("names") = rownames;
+
+  // For the computing, we work on the kth slice of trans for each
+  // genetic marker separately, and also divvy up vatilde into blocks
+  // for the matrix multiplication.
+  arma::mat varq(ntrait, ntrait);
+  for (arma::uword k = 0; k < n; k++) {
+    for (arma::uword i = 0; i < varq.n_rows; i++) {
+      for (arma::uword j = 0; j < varq.n_cols; j++) {
+        varq.submat(i, j, i, j) = trans_mat.row(k) * 
+            vatilde_mat.submat(i*p, j*p, (i+1)*p - 1, (j+1)*p - 1) *
+            trans_mat.row(k).t();
+      }
+    }
+    vqtilde[k] = arma::trace(Ginv_mat * varq);
+  }
+  return vqtilde;
+}
+
+
+
+
+/*
+// Old Eigen solution (couldn't get this to work)
+// //' Computes the matrix product vqtilde. Assumes R base matrix inputs.
+//  //'
+//  //' @param trans The matrix product M^T(MM^T)^{-1}, typically many rows
+//  //' @param Ginv The inverse matrix G_a^-
+//  //' @param vatilde The variance matrix var(tilde(a))
+//  //' @param ntrait The number of traits
+//  //' @return The matrix vqtilde
+//  //' @noRd
+//  // [[Rcpp::export]]
+// Eigen::MatrixXd compute_vqtilde(Eigen::Map<Eigen::MatrixXd> trans,
+//     Eigen::Map<Eigen::MatrixXd> Ginv, Eigen::Map<Eigen::MatrixXd> vatilde,
+//     int ntrait) {
+//   std::cout << "got here" << std::endl;
+
+//   // We work on the kth slice of trans for each genetic marker
+//   // separately, and also divvy up vatilde into blocks for the
+//   // matrix multiplication.
+//   int n = trans.rows(), p = trans.cols(), q = vatilde.rows();
+//   Eigen::MatrixXd varq(ntrait, ntrait), vqtilde(n, 1);
+//   for (int k = 0; k < n; k++) {
+//     for (int i = 0; i < varq.rows(); i++) {
+//       for (int j = 0; j < varq.cols(); j++) {
+//         varq(i, j) = trans.row(k) * vatilde.block(i*p, j*q, p, q) *
+//             trans.row(k).transpose();
+//       }
+//     }
+//     vqtilde(k, 1) = (Ginv * varq).trace();
+//   }
+
+//   return vqtilde;
+// }
+*/

--- a/src/compute_vqtilde.cpp
+++ b/src/compute_vqtilde.cpp
@@ -1,7 +1,7 @@
 /**
- * C+ code (using the Eigen libraries via RcppArmadillo) to compute the
- * vqtilde component for the multivariate outlier statistics and speed
- * up processing in the qtlSelect() function.
+ * C+ code (using the Armadillo libraries via RcppArmadillo) to compute
+ * the vqtilde component for the multivariate outlier statistics and
+ * speed up processing in the qtlSelect() function.
  *
  * Code author: Russell Edson, Biometry Hub
  * Date last modified: 20/04/2024
@@ -53,41 +53,3 @@ Rcpp::NumericVector compute_vqtilde(Rcpp::NumericMatrix trans,
   }
   return vqtilde;
 }
-
-
-
-
-/*
-// Old Eigen solution (couldn't get this to work)
-// //' Computes the matrix product vqtilde. Assumes R base matrix inputs.
-//  //'
-//  //' @param trans The matrix product M^T(MM^T)^{-1}, typically many rows
-//  //' @param Ginv The inverse matrix G_a^-
-//  //' @param vatilde The variance matrix var(tilde(a))
-//  //' @param ntrait The number of traits
-//  //' @return The matrix vqtilde
-//  //' @noRd
-//  // [[Rcpp::export]]
-// Eigen::MatrixXd compute_vqtilde(Eigen::Map<Eigen::MatrixXd> trans,
-//     Eigen::Map<Eigen::MatrixXd> Ginv, Eigen::Map<Eigen::MatrixXd> vatilde,
-//     int ntrait) {
-//   std::cout << "got here" << std::endl;
-
-//   // We work on the kth slice of trans for each genetic marker
-//   // separately, and also divvy up vatilde into blocks for the
-//   // matrix multiplication.
-//   int n = trans.rows(), p = trans.cols(), q = vatilde.rows();
-//   Eigen::MatrixXd varq(ntrait, ntrait), vqtilde(n, 1);
-//   for (int k = 0; k < n; k++) {
-//     for (int i = 0; i < varq.rows(); i++) {
-//       for (int j = 0; j < varq.cols(); j++) {
-//         varq(i, j) = trans.row(k) * vatilde.block(i*p, j*q, p, q) *
-//             trans.row(k).transpose();
-//       }
-//     }
-//     vqtilde(k, 1) = (Ginv * varq).trace();
-//   }
-
-//   return vqtilde;
-// }
-*/


### PR DESCRIPTION
Replaces the `lapply` loop over the M^T(MM^T)^(-1) matrix with a faster implementation using RcppArmadillo and a slight rearrangement of the var(q) computation. We seem to get a consistent 4.5x speed-up with the new C++ version, with identical outputs on the test case (which was just subsetting the test matrix Beata sent us):
![image](https://github.com/DrJ001/mvwgaim/assets/8025610/1cade8d6-a7a5-47ca-b424-704448e8523f)
